### PR TITLE
Symfony Yaml Library Inclusion

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     "ext-curl": "*",
     "jms/serializer": "~0.16",
     "symfony/event-dispatcher": "~2.2",
+    "symfony/yaml": "~2.6",
     "guzzlehttp/guzzle": ">=4.2",
     "doctrine/collections": "~1.2"
   },


### PR DESCRIPTION
@cleentfaar: Resolves #11

Although there may be an issue with an included library not correctly declaring their own dependencies, friction can and should be reduced for users of the "cleentfaar/slack" package by masking them from this problem and taking the issue up separately with any maintainers of the underlying dependency libraries.

Wonderful library you have - thanks for considering the patch!