### PR TITLE
Adding subtype and attachments to SimpleMessage

### DIFF
--- a/src/CL/Slack/Model/SimpleMessage.php
+++ b/src/CL/Slack/Model/SimpleMessage.php
@@ -29,6 +29,11 @@ class SimpleMessage extends AbstractModel
     protected $type;
 
     /**
+     * @var string
+     */
+    protected $subtype;
+
+    /**
      * @var SimpleChannel
      */
     private $channel;
@@ -47,6 +52,11 @@ class SimpleMessage extends AbstractModel
      * @var string
      */
     protected $text;
+
+    /**
+     * @var array
+     */
+    protected $attachments = array();
 
     /**
      * @return string|null The Slack timestamp on which the message was posted

--- a/src/CL/Slack/Resources/config/serializer/CL.Slack.Model.Attachment.yml
+++ b/src/CL/Slack/Resources/config/serializer/CL.Slack.Model.Attachment.yml
@@ -4,6 +4,8 @@ CL\Slack\Model\Attachment:
             type: string
         preText:
             type: string
+        imageUrl:
+            type: string
         text:
             type: string
         color:

--- a/src/CL/Slack/Resources/config/serializer/CL.Slack.Model.SimpleMessage.yml
+++ b/src/CL/Slack/Resources/config/serializer/CL.Slack.Model.SimpleMessage.yml
@@ -4,6 +4,8 @@ CL\Slack\Model\SimpleMessage:
             type: string
         type:
             type: string
+        subtype:
+            type: string
         channel:
             type: CL\Slack\Model\SimpleChannel
         user:
@@ -12,3 +14,5 @@ CL\Slack\Model\SimpleMessage:
             type: string
         text:
             type: string
+        attachments:
+            type: array<CL\Slack\Model\Attachment>


### PR DESCRIPTION
Documentation for the added properties: https://api.slack.com/events/message

## Subtype
> Unlike other event types, message events can have a subtype

## Attachments
> Messages can also include an attachments property, containing a list of attachment objects.
https://api.slack.com/docs/attachments