### PR TITLE
Attachments must be in json format

### DIFF
--- a/src/CL/Slack/Payload/AdvanceSerializeInterface.php
+++ b/src/CL/Slack/Payload/AdvanceSerializeInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+
+namespace CL\Slack\Payload;
+
+
+use JMS\Serializer\Serializer;
+
+interface AdvanceSerializeInterface
+{
+    /**
+     * Prepare date to serialize
+     *
+     * @param Serializer $serializer
+     */
+    public function beforeSerialize(Serializer $serializer);
+}

--- a/src/CL/Slack/Payload/AdvancedSerializeInterface.php
+++ b/src/CL/Slack/Payload/AdvancedSerializeInterface.php
@@ -6,7 +6,7 @@ namespace CL\Slack\Payload;
 
 use JMS\Serializer\Serializer;
 
-interface AdvanceSerializeInterface
+interface AdvancedSerializeInterface
 {
     /**
      * Prepare date to serialize

--- a/src/CL/Slack/Payload/AdvancedSerializeInterface.php
+++ b/src/CL/Slack/Payload/AdvancedSerializeInterface.php
@@ -9,7 +9,7 @@ use JMS\Serializer\Serializer;
 interface AdvancedSerializeInterface
 {
     /**
-     * Prepare date to serialize
+     * Prepare data to serialize
      *
      * @param Serializer $serializer
      */

--- a/src/CL/Slack/Payload/ChatPostMessagePayload.php
+++ b/src/CL/Slack/Payload/ChatPostMessagePayload.php
@@ -13,13 +13,14 @@ namespace CL\Slack\Payload;
 
 use CL\Slack\Model\Attachment;
 use Doctrine\Common\Collections\ArrayCollection;
+use JMS\Serializer\Serializer;
 
 /**
  * @author Cas Leentfaar <info@casleentfaar.com>
  *
  * @link Official documentation at https://api.slack.com/methods/chat.postMessage
  */
-class ChatPostMessagePayload extends AbstractPayload
+class ChatPostMessagePayload extends AbstractPayload implements AdvanceSerializeInterface
 {
     /**
      * @var string
@@ -70,6 +71,11 @@ class ChatPostMessagePayload extends AbstractPayload
      * @var Attachment[]|ArrayCollection
      */
     private $attachments;
+
+    /**
+     * @var string
+     */
+    private $attachmentsJson;
 
     public function __construct()
     {
@@ -283,10 +289,28 @@ class ChatPostMessagePayload extends AbstractPayload
     }
 
     /**
+     * Use for serialization
+     *
+     * @return string
+     */
+    public function getAttachmentsJson()
+    {
+        return $this->attachmentsJson;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function getMethod()
     {
         return 'chat.postMessage';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function beforeSerialize (Serializer $serializer)
+    {
+        $this->attachmentsJson = $serializer->serialize($this->attachments, 'json');
     }
 }

--- a/src/CL/Slack/Payload/ChatPostMessagePayload.php
+++ b/src/CL/Slack/Payload/ChatPostMessagePayload.php
@@ -20,7 +20,7 @@ use JMS\Serializer\Serializer;
  *
  * @link Official documentation at https://api.slack.com/methods/chat.postMessage
  */
-class ChatPostMessagePayload extends AbstractPayload implements AdvanceSerializeInterface
+class ChatPostMessagePayload extends AbstractPayload implements AdvancedSerializeInterface
 {
     /**
      * @var string

--- a/src/CL/Slack/Resources/config/serializer/CL.Slack.Payload.ChatPostMessagePayload.yml
+++ b/src/CL/Slack/Resources/config/serializer/CL.Slack.Payload.ChatPostMessagePayload.yml
@@ -1,4 +1,5 @@
 CL\Slack\Payload\ChatPostMessagePayload:
+    exclusion_policy: ALL
     properties:
         channel:
             type: string
@@ -19,4 +20,6 @@ CL\Slack\Payload\ChatPostMessagePayload:
         parse:
             type: string
         attachments:
-            type: ArrayCollection<CL\Slack\Model\Attachment>
+            type: string
+            accessor:
+                getter: getAttachmentsJson

--- a/src/CL/Slack/Serializer/PayloadSerializer.php
+++ b/src/CL/Slack/Serializer/PayloadSerializer.php
@@ -32,6 +32,7 @@ class PayloadSerializer extends AbstractSerializer
         }
 
         $serializedPayload = $this->serializer->serialize($payload, 'json');
+
         if (!$serializedPayload || !is_string($serializedPayload)) {
             throw new \RuntimeException(sprintf(
                 'Failed to serialize payload; expected it to be a string, got: %s',

--- a/src/CL/Slack/Serializer/PayloadSerializer.php
+++ b/src/CL/Slack/Serializer/PayloadSerializer.php
@@ -11,7 +11,7 @@
 
 namespace CL\Slack\Serializer;
 
-use CL\Slack\Payload\AdvanceSerializeInterface;
+use CL\Slack\Payload\AdvancedSerializeInterface;
 use CL\Slack\Payload\ChatPostMessagePayload;
 use CL\Slack\Payload\PayloadInterface;
 
@@ -27,9 +27,10 @@ class PayloadSerializer extends AbstractSerializer
      */
     public function serialize(PayloadInterface $payload)
     {
-        if ($payload instanceof AdvanceSerializeInterface) {
+        if ($payload instanceof AdvancedSerializeInterface) {
             $payload->beforeSerialize($this->serializer);
         }
+
         $serializedPayload = $this->serializer->serialize($payload, 'json');
         if (!$serializedPayload || !is_string($serializedPayload)) {
             throw new \RuntimeException(sprintf(

--- a/src/CL/Slack/Serializer/PayloadSerializer.php
+++ b/src/CL/Slack/Serializer/PayloadSerializer.php
@@ -33,6 +33,11 @@ class PayloadSerializer extends AbstractSerializer
             ));
         }
 
-        return json_decode($serializedPayload, true);
+        //Attachments must be in json format
+        $payloadArray = json_decode($serializedPayload, true);
+        if (isset($payloadArray['attachments'])) {
+            $payloadArray['attachments'] = json_encode($payloadArray['attachments']);
+        }
+        return $payloadArray;
     }
 }

--- a/src/CL/Slack/Serializer/PayloadSerializer.php
+++ b/src/CL/Slack/Serializer/PayloadSerializer.php
@@ -11,6 +11,8 @@
 
 namespace CL\Slack\Serializer;
 
+use CL\Slack\Payload\AdvanceSerializeInterface;
+use CL\Slack\Payload\ChatPostMessagePayload;
 use CL\Slack\Payload\PayloadInterface;
 
 /**
@@ -25,6 +27,9 @@ class PayloadSerializer extends AbstractSerializer
      */
     public function serialize(PayloadInterface $payload)
     {
+        if ($payload instanceof AdvanceSerializeInterface) {
+            $payload->beforeSerialize($this->serializer);
+        }
         $serializedPayload = $this->serializer->serialize($payload, 'json');
         if (!$serializedPayload || !is_string($serializedPayload)) {
             throw new \RuntimeException(sprintf(
@@ -33,11 +38,6 @@ class PayloadSerializer extends AbstractSerializer
             ));
         }
 
-        //Attachments must be in json format
-        $payloadArray = json_decode($serializedPayload, true);
-        if (isset($payloadArray['attachments'])) {
-            $payloadArray['attachments'] = json_encode($payloadArray['attachments']);
-        }
-        return $payloadArray;
+        return json_decode($serializedPayload, true);
     }
 }

--- a/src/CL/Slack/Tests/Payload/ChatPostMessagePayloadTest.php
+++ b/src/CL/Slack/Tests/Payload/ChatPostMessagePayloadTest.php
@@ -87,19 +87,19 @@ class ChatPostMessagePayloadTest extends AbstractPayloadTest
                 [
                     'title'       => $attachment->getTitle(),
                     'title_link'  => $attachment->getTitleLink(),
-                    'pre_text'    => $attachment->getPreText(),
-                    'text'        => $attachment->getText(),
+                    'image_url'   => $attachment->getImageUrl(),
                     'author_name' => $attachment->getAuthorName(),
                     'author_link' => $attachment->getAuthorLink(),
                     'author_icon' => $attachment->getAuthorIcon(),
+                    'pre_text'    => $attachment->getPreText(),
+                    'text'        => $attachment->getText(),
                     'color'       => $attachment->getColor(),
                     'fallback'    => $attachment->getFallback(),
-                    'image_url'   => $attachment->getImageUrl(),
                     'fields'      => [
                         [
                             'title' => $attachmentField->getTitle(),
-                            'short' => $attachmentField->isShort(),
                             'value' => $attachmentField->getValue(),
+                            'short' => $attachmentField->isShort(),
                         ],
                     ],
                 ],

--- a/src/CL/Slack/Tests/Payload/ChatPostMessagePayloadTest.php
+++ b/src/CL/Slack/Tests/Payload/ChatPostMessagePayloadTest.php
@@ -83,7 +83,7 @@ class ChatPostMessagePayloadTest extends AbstractPayloadTest
             'unfurl_links' => $payload->getUnfurlLinks(),
             'link_names'   => $payload->getLinkNames(),
             'parse'        => $payload->getParse(),
-            'attachments'  => [
+            'attachments'  => json_encode([
                 [
                     'title'       => $attachment->getTitle(),
                     'title_link'  => $attachment->getTitleLink(),
@@ -103,7 +103,7 @@ class ChatPostMessagePayloadTest extends AbstractPayloadTest
                         ],
                     ],
                 ],
-            ],
+            ]),
         ];
     }
 }


### PR DESCRIPTION
Uncorrect attachment serialization. Slack not accept attachment without encoding.