### PR TITLE
ApiClient uses guzzlehttp/guzzle 4.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "jms/serializer": "~0.16",
     "symfony/event-dispatcher": "~2.2",
     "symfony/yaml": "~2.2",
-    "guzzlehttp/guzzle": ">=4.2",
+    "guzzlehttp/guzzle": "4.2.*",
     "doctrine/collections": "~1.2"
   },
   "require-dev": {


### PR DESCRIPTION
https://github.com/guzzle/guzzle/blob/master/UPGRADING.md
4.x to 5.0
Removed Fluent Interfaces:
GuzzleHttp\Post\PostBody

This is used in CL\Slack\Transport\ApiClient