### PR TITLE
Deserializing messages fixed

### DIFF
--- a/src/CL/Slack/Resources/config/serializer/CL.Slack.Model.Message.yml
+++ b/src/CL/Slack/Resources/config/serializer/CL.Slack.Model.Message.yml
@@ -10,5 +10,11 @@ CL\Slack\Model\Message:
             type: string
         text:
             type: string
+        permalink:
+            type: string
         channel:
             type: CL\Slack\Model\Channel
+        previous:
+            type: CL\Slack\Model\Message
+        next:
+            type: CL\Slack\Model\Message

--- a/src/CL/Slack/Resources/doc/methods/search-all.md
+++ b/src/CL/Slack/Resources/doc/methods/search-all.md
@@ -26,7 +26,7 @@ $response = $apiClient->send($payload);
 
 if ($response->isOk()) {
     // query has been executed and result is returned (but can be empty)
-    $response->getMessageResult()->getMatches(); // Message objects
+    $response->getResult()->getMatches(); // Message objects
     $response->getFileResult()->getMatches(); // File objects
 } else {
     // something went wrong, but what?


### PR DESCRIPTION
When you called the messages.search API method, the JMS serializer throw an error "you should define a type of permalink". So I fixed that and every error which occurred later. 