### PR TITLE
Fixing missing JMS type

### DIFF
--- a/src/CL/Slack/Resources/config/serializer/CL.Slack.Model.Attachment.yml
+++ b/src/CL/Slack/Resources/config/serializer/CL.Slack.Model.Attachment.yml
@@ -1,5 +1,7 @@
 CL\Slack\Model\Attachment:
     properties:
+        title:
+            type: string
         fallback:
             type: string
         preText:


### PR DESCRIPTION
to avoid:

````
[CL\Slack\Exception\SlackException]
Failed to send payload: You must define a type for CL\Slack\Model\Attachment::$title.
...
[JMS\Serializer\Exception\RuntimeException]
You must define a type for CL\Slack\Model\Attachment::$title.
````
while doing

```php
$client = new ApiClient(...);
$payload = new SearchMessagesPayload();
$payload->setQuery('...');
$response = $client->send($payload);
````