### PR TITLE
+ Fix Attachment model missing type definition for mrkdwnIn

### DIFF
--- a/src/CL/Slack/Resources/config/serializer/CL.Slack.Model.Attachment.yml
+++ b/src/CL/Slack/Resources/config/serializer/CL.Slack.Model.Attachment.yml
@@ -14,3 +14,5 @@ CL\Slack\Model\Attachment:
             type: string
         fields:
             type: ArrayCollection<CL\Slack\Model\AttachmentField>
+        mrkdwnIn:
+            type: array


### PR DESCRIPTION
Missing mrkdwnIn type definition got me JMS\Serializer\Exception\RuntimeException with message: "You must define a type for CL\Slack\Model\Attachment::$mrkdwnIn" when calling channel.invite API (the API returns latest posts containing attachments.) I suppose this will also occurs on other API returning attachments.