### PR TITLE
Fix groups.invite responses where user is already in group

### DIFF
--- a/src/CL/Slack/Payload/GroupsInvitePayloadResponse.php
+++ b/src/CL/Slack/Payload/GroupsInvitePayloadResponse.php
@@ -39,7 +39,7 @@ class GroupsInvitePayloadResponse extends AbstractPayloadResponse
     /**
      * @return bool|null
      */
-    public function getAlreadyInGroup()
+    public function isAlreadyInGroup()
     {
         return $this->alreadyInGroup;
     }

--- a/src/CL/Slack/Resources/config/serializer/CL.Slack.Payload.GroupsInvitePayloadResponse.yml
+++ b/src/CL/Slack/Resources/config/serializer/CL.Slack.Payload.GroupsInvitePayloadResponse.yml
@@ -2,3 +2,5 @@ CL\Slack\Payload\GroupsInvitePayloadResponse:
     properties:
         group:
             type: CL\Slack\Model\Group
+        alreadyInGroup:
+            type: boolean

--- a/tests/src/CL/Slack/Tests/Payload/GroupsInvitePayloadResponseTest.php
+++ b/tests/src/CL/Slack/Tests/Payload/GroupsInvitePayloadResponseTest.php
@@ -26,6 +26,7 @@ class GroupsInvitePayloadResponseTest extends AbstractPayloadResponseTestCase
     {
         return [
             'group' => $this->createGroup(),
+            'already_in_group' => true,
         ];
     }
 
@@ -38,5 +39,6 @@ class GroupsInvitePayloadResponseTest extends AbstractPayloadResponseTestCase
     protected function assertResponse(array $responseData, PayloadResponseInterface $payloadResponse)
     {
         $this->assertGroup($responseData['group'], $payloadResponse->getGroup());
+        $this->assertEquals($responseData['already_in_group'], $payloadResponse->getAlreadyInGroup());
     }
 }

--- a/tests/src/CL/Slack/Tests/Payload/GroupsInvitePayloadResponseTest.php
+++ b/tests/src/CL/Slack/Tests/Payload/GroupsInvitePayloadResponseTest.php
@@ -39,6 +39,6 @@ class GroupsInvitePayloadResponseTest extends AbstractPayloadResponseTestCase
     protected function assertResponse(array $responseData, PayloadResponseInterface $payloadResponse)
     {
         $this->assertGroup($responseData['group'], $payloadResponse->getGroup());
-        $this->assertEquals($responseData['already_in_group'], $payloadResponse->getAlreadyInGroup());
+        $this->assertEquals($responseData['already_in_group'], $payloadResponse->isAlreadyInGroup());
     }
 }


### PR DESCRIPTION
This adds the missing serializer configuration for the `alreadyInGroup` property, fixing the exception: `Failed to send payload: You must define a type for CL\Slack\Payload\GroupsInvitePayloadResponse::$alreadyInGroup.`.

The thing I wasn't sure about was renaming the method to use "is" instead of "get" to follow the conventions used elsewhere in response classes. As I see it, you can't have really been using that method anyway due to the deserialization error, but it's arguably a BC break.
