### PR TITLE
Add accessors for Attachments in SimpleMessage Class

### DIFF
--- a/src/CL/Slack/Model/SimpleMessage.php
+++ b/src/CL/Slack/Model/SimpleMessage.php
@@ -107,4 +107,20 @@ class SimpleMessage extends AbstractModel
     {
         return $this->text;
     }
+
+    /**
+     * @return array of attachments
+     */
+    public function getAttachments()
+    {
+        return $this->attachments;
+    }
+
+    /**
+     * @return boolean wether or not this message has attachments
+     */
+    public function hasAttachments()
+    {
+        return count($this->attachments) > 0;
+    }
 }


### PR DESCRIPTION
this adds two new methods to the SimpleMessage class. The first is an accessor method for attachments ```getAttachments()```, and the second is a convenience method for checking if a SimpleMessage has any attachment at all ```hasAttachments()```

Fixes issue #67