### PR TITLE
Fix 'Attachment model missing type definition for' errors

### DIFF
--- a/src/CL/Slack/Resources/config/serializer/CL.Slack.Model.Attachment.yml
+++ b/src/CL/Slack/Resources/config/serializer/CL.Slack.Model.Attachment.yml
@@ -12,5 +12,16 @@ CL\Slack\Model\Attachment:
             type: string
         color:
             type: string
+        mrkdwnIn:
+            type: array
+        titleLink:
+            type: string
+        authorName:
+            type: string
+        authorLink:
+            type: string
+        authorIcon:
+            type: string
         fields:
             type: ArrayCollection<CL\Slack\Model\AttachmentField>
+        


### PR DESCRIPTION
While testing out this library I found that I received  'Attachment model missing type definition for' errors until making the changes to the Attachment Resource to include the following additions:

```

        mrkdwnIn:
            type: array
        titleLink:
            type: string
        authorName:
            type: string
        authorLink:
            type: string
        authorIcon:
            type: string

```

Fixes #66