### PR TITLE
'missing_scope' error handling

### DIFF
--- a/src/CL/Slack/Payload/AbstractPayloadResponse.php
+++ b/src/CL/Slack/Payload/AbstractPayloadResponse.php
@@ -17,6 +17,10 @@ abstract class AbstractPayloadResponse implements PayloadResponseInterface
      */
     private $error;
 
+    private $needed;
+
+    private $provided;
+
     /**
      * @inheritdoc
      */
@@ -79,6 +83,8 @@ abstract class AbstractPayloadResponse implements PayloadResponseInterface
             'user_is_bot' => 'This method cannot be called by a bot user',
             'user_is_ultra_restricted' => 'This method cannot be called by a single channel guest',
             'user_not_found' => 'User could not be found',
+	        'missing_scope' => sprintf("The application's permissions is not enough to complete this request. Needed scope is '%s', provided - [%s].",
+		        $this->needed, $this->provided),
         ];
     }
 }

--- a/src/CL/Slack/Payload/AbstractPayloadResponse.php
+++ b/src/CL/Slack/Payload/AbstractPayloadResponse.php
@@ -17,8 +17,14 @@ abstract class AbstractPayloadResponse implements PayloadResponseInterface
      */
     private $error;
 
+	/**
+	 * @var string
+	 */
     private $needed;
 
+	/**
+	 * @var string
+	 */
     private $provided;
 
     /**

--- a/src/CL/Slack/Resources/config/serializer/CL.Slack.Payload.AbstractPayloadResponse.yml
+++ b/src/CL/Slack/Resources/config/serializer/CL.Slack.Payload.AbstractPayloadResponse.yml
@@ -4,3 +4,7 @@ CL\Slack\Payload\AbstractPayloadResponse:
             type: boolean
         error:
             type: string
+        needed:
+            type: string
+        provided:
+            type: string


### PR DESCRIPTION
Added properties to the abstract class of response payload for scope that needed to complete the requested method and scopes that provided by application. 
Added explanation for error 'missing_scope' that includes details about needed scope and scopes, provided by the application.